### PR TITLE
releasetools: do not remove dynamic partitions in system-only builds

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -2423,13 +2423,15 @@ class DynamicGroupUpdate(object):
 
 class DynamicPartitionsDifference(object):
   def __init__(self, info_dict, block_diffs, progress_dict=None,
-               source_info_dict=None):
+               source_info_dict=None, build_without_vendor=False):
     if progress_dict is None:
       progress_dict = dict()
 
+    self._build_without_vendor = build_without_vendor
     self._remove_all_before_apply = False
     if source_info_dict is None:
-      self._remove_all_before_apply = True
+      if not build_without_vendor:
+        self._remove_all_before_apply = True
       source_info_dict = dict()
 
     block_diff_dict = {e.partition:e for e in block_diffs}
@@ -2553,6 +2555,17 @@ class DynamicPartitionsDifference(object):
       comment('Remove all existing dynamic partitions and groups before '
               'applying full OTA')
       append('remove_all_groups')
+
+    if self._build_without_vendor:
+      comment('System-only build, keep original vendor partitions')
+      # When building without vendor, we do not want to override
+      # any partition already existing. In this case, we can only
+      # resize, but not remove / create / re-create any other
+      # partition.
+      for p, u in self._partition_updates.items():
+        comment('Resize partition %s to %s' % (p, u.tgt_size))
+        append('resize %s %s' % (p, u.tgt_size))
+      return
 
     for p, u in self._partition_updates.items():
       if u.src_group and not u.tgt_group:


### PR DESCRIPTION
* Before this commit, the generated `dynamic_partitions_op_list` in
  FullOTA packages always tries to remove all partitions and recreate
  them upon flashing. This makes it impossible to have a system-only
  "FullOTA" because vendor partition(s) are always removed.
* This commit detects if a build is vendor-less and disables every
  dynamic partition operation except `resize`, in order to keep the
  original content around after the flash. The change should not affect
  non-dynamic-partition or builds with vendor image included.